### PR TITLE
ci: remove the artifact examples

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -117,7 +117,6 @@ jobs:
         uses: ansys/actions/release-github@v7
         with:
           library-name: ${{ env.LIBRARY_NAME }}
-          additional-artifacts: 'examples'
 
   doc-deploy-dev:
     name: "Deploy development documentation"

--- a/doc/changelog.d/27.maintenance.md
+++ b/doc/changelog.d/27.maintenance.md
@@ -1,0 +1,1 @@
+ci: remove the artifact examples


### PR DESCRIPTION
Remove the artifact examples from the publishing action, since it does not exist.