### PR TITLE
fix: Make sure the directory %APPDATA%\SCADE\Customize exists when registering the package

### DIFF
--- a/doc/changelog.d/31.fixed.md
+++ b/doc/changelog.d/31.fixed.md
@@ -1,0 +1,1 @@
+fix: Make sure the directory %APPDATA%\SCADE\Customize exists when registering the package

--- a/src/ansys/scade/git/register.py
+++ b/src/ansys/scade/git/register.py
@@ -110,6 +110,7 @@ def register_srg_file(srg: Path, install: Path):
     text = srg.open().read()
     text = text.replace('%TARGETDIR%', install.as_posix())
     dst = Path(APPDATA, 'SCADE', 'Customize', srg.name)
+    dst.parent.mkdir(parents=True, exist_ok=True)
     dst.open('w').write(text)
 
 


### PR DESCRIPTION
Closes #30 