### PR TITLE
fix: Enhance robustness

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ maintainers = [
 ]
 dependencies=[
     "ansys-scade-apitools",
-    "dulwich>=0.21.3",
+    # recent versions of dulwich have a different behavior
+    "dulwich==0.21.3, < 0.21.4",
     "importlib-metadata >= 1.0; python_version < '3.8'",
     "importlib-metadata >= 4.0; python_version >= '3.8'",
     "lxml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,8 @@ unregister_ansys_scade_git = "ansys.scade.git.unregister:main"
 
 [tool.ruff]
 line-length = 100
+
+[tool.ruff.lint]
 select = [
     "E",    # pycodestyle, see https://beta.ruff.rs/docs/rules/#pycodestyle-e-w
     "D",    # pydocstyle, see https://beta.ruff.rs/docs/rules/#pydocstyle-d
@@ -93,7 +95,7 @@ ignore = [
 [tool.ruff.format]
 quote-style = "preserve"
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 combine-as-imports = true
 force-sort-within-sections = true
 known-first-party = ["ansys", "conftest", "test_utils"]

--- a/src/ansys/scade/git/etpmerge/__main__.py
+++ b/src/ansys/scade/git/etpmerge/__main__.py
@@ -51,6 +51,7 @@ def main():
     parser.add_argument('-m', '--merged', metavar='<merged>', help='merged file', required=True)
     options = parser.parse_args()
 
+    assert declare_project  # nosec B101  # declare_project must be defined on Windows
     declare_project(options.local)
     declare_project(options.remote)
     declare_project(options.base)

--- a/src/ansys/scade/git/etpmerge/cache.py
+++ b/src/ansys/scade/git/etpmerge/cache.py
@@ -61,8 +61,8 @@ class CacheMaps(Visit):
 
     def __init__(self):
         """Declare global maps, to be accessed from any elements."""
-        self.map_ids = None
-        self.map_files = None
+        self.map_ids = {}
+        self.map_files = {}
 
     def visit_project(self, project: std.Project):
         """Add the attributes for a project."""

--- a/src/ansys/scade/git/etpmerge/cache.py
+++ b/src/ansys/scade/git/etpmerge/cache.py
@@ -67,7 +67,7 @@ class CacheMaps(Visit):
     def visit_project(self, project: std.Project):
         """Add the attributes for a project."""
         # the cache must be used once per project
-        assert not hasattr(project, '_map_ids')
+        # assert not hasattr(project, '_map_ids')
         # initialize the extra attributes tp be accessed during the visit
         project._map_ids = {}
         self.map_ids = project._map_ids
@@ -150,7 +150,7 @@ class CacheBase(Visit):
 
     def visit_project(self, project: std.Project):
         """Initialize the current folder hierarchy with the project."""
-        assert self.resolve_by_id(project)
+        self.resolve_by_id(project)
         self.hierarchy.append(project)
         super().visit_project(project)
         self.hierarchy.pop()
@@ -188,6 +188,6 @@ class CacheBase(Visit):
             raise WrongBaseError(project_entity)
 
         # the cache must be used once per project
-        assert not hasattr(project_entity, '_base')
+        # assert not hasattr(project_entity, '_base')
         project_entity._base = base
         return base is not None

--- a/src/ansys/scade/git/etpmerge/checkids.py
+++ b/src/ansys/scade/git/etpmerge/checkids.py
@@ -63,6 +63,7 @@ def main():
     parser.add_argument('-p', '--project', metavar='<project>', help='project file', required=True)
     options = parser.parse_args()
 
+    assert declare_project  # nosec B101  # declare_project must be defined on Windows
     declare_project(options.project)
     # load the declared projects
     project = get_projects()[0]

--- a/src/ansys/scade/git/etpmerge/etpmerge3.py
+++ b/src/ansys/scade/git/etpmerge/etpmerge3.py
@@ -128,7 +128,7 @@ class EtpMerge3:
                 else:
                     # configuration deleted locally
                     remote._local = None
-            assert hasattr(remote, '_local')
+            # assert hasattr(remote, '_local')
         # delete the remaining configurations which are not new
         for local in locals:
             if local._base:
@@ -291,8 +291,8 @@ class EtpMerge3:
         remote_entity : Annotable
             Remote owner of the properties to be merged.
         """
-        assert remote_entity._local
         local_entity = remote_entity._local
+        assert local_entity is not None  # nosec B101  # addresses linter
         # save the list of local props, remaining items
         # in this list are deleted properties
         locals = set(local_entity.props)
@@ -352,11 +352,12 @@ class EtpMerge3:
         # -> The properties having one and only one value are considered as scalar:
         #    this may introduce 'false' conflicts.
 
-        assert (
-            not local_entity._base
-            or not remote_entity._base
-            or local_entity._base == remote_entity._base
-        )
+        # context:
+        # assert (
+        #     not local_entity._base
+        #     or not remote_entity._base
+        #     or local_entity._base == remote_entity._base
+        # )
         # note: if/else rather than =/if/else for code coverage
         if local_entity._base:
             base_values = local_entity._base.values

--- a/src/ansys/scade/git/etpmerge/fi.py
+++ b/src/ansys/scade/git/etpmerge/fi.py
@@ -132,7 +132,8 @@ def copy_prop(prop: std.Prop, owner: std.Annotable) -> std.Prop:
         configuration = prop.configuration._local
     else:
         configuration = None
-    copy = create_prop(owner, configuration, prop.name, prop.values)
+    # typing annotation incorrect for configuration
+    copy = create_prop(owner, configuration, prop.name, prop.values)  # type: ignore
     copy._base = prop._base
     prop._local = copy
     return copy

--- a/src/ansys/scade/git/etpmerge/utils.py
+++ b/src/ansys/scade/git/etpmerge/utils.py
@@ -22,12 +22,12 @@
 
 """Provides helpers for reporting and computations."""
 
-from typing import Any
+from typing import Any, Optional
 
 import scade.model.project.stdproject as std
 
 
-def get_prop_key(prop: std.Prop, configuration: std.Configuration = None) -> Any:
+def get_prop_key(prop: std.Prop, configuration: Optional[std.Configuration] = None) -> Any:
     """
     Return the key to find a prop by name: (name, configuration's id).
 
@@ -35,7 +35,7 @@ def get_prop_key(prop: std.Prop, configuration: std.Configuration = None) -> Any
     ----------
     prop : std.Prop
         Input property.
-    configuration : std.Configuration
+    configuration : std.Configuration | None
         When not None, it is the configuration to consider instead of the one linked
         to the property. This is usually the property's configuration's local.
 

--- a/src/ansys/scade/git/etpmerge/visitor.py
+++ b/src/ansys/scade/git/etpmerge/visitor.py
@@ -30,7 +30,8 @@ class Visit:
 
     def visit(self, project_entity: std.ProjectEntity):
         """Entry point of the visit."""
-        eval("self.%s(project_entity)" % _map_visit_functions[type(project_entity)])
+        fct = getattr(type(self), _map_visit_functions[type(project_entity)])
+        fct(self, project_entity)
 
     def visit_annotable(self, annotable: std.Annotable):
         """Visit function for Annotable."""

--- a/src/ansys/scade/git/extension/gitextcore.py
+++ b/src/ansys/scade/git/extension/gitextcore.py
@@ -22,7 +22,6 @@
 
 """SCADE custom extension for Git."""
 
-from inspect import getsourcefile
 import os
 from pathlib import Path
 import shutil
@@ -95,14 +94,15 @@ def report_item(ide: Ide, item: Union[Project, FileRef, str]) -> str:
     item: Union[Project, FileRef, str]
         Element to add to the browser: Either a SCADE Python object or a string.
     """
+    assert _git_client is not None  # nosec B101  # addresses linter
     if isinstance(item, str):
         index_file_name, status = _git_client.get_file_status(item)
-        browser_cat, icon = status_data.get(status, GitStatus.extern)
+        browser_cat, icon = status_data.get(status, status_data[GitStatus.extern])
         project_files_status[browser_cat].append(index_file_name)
         ide.browser_report(index_file_name, browser_cat, icon_file=icon)
     else:
         index_file_name, status = _git_client.get_file_status(item.pathname)
-        browser_cat, icon = status_data.get(status, GitStatus.extern)
+        browser_cat, icon = status_data.get(status, status_data[GitStatus.extern])
         project_files_status[browser_cat].append(index_file_name)
         if isinstance(item, Project):
             name = index_file_name
@@ -121,6 +121,7 @@ def refresh_browser(ide: Ide):
     ide : Studio
         SCADE IDE environment.
     """
+    assert _git_client is not None  # nosec B101  # addresses linter
     active_project = ide.get_active_project()
     if active_project:
         # save project before Git refresh
@@ -201,6 +202,7 @@ class GitRepoCommand(Command):
 
     def on_enable(self) -> bool:
         """Enable the command if the Git repository exists and is refreshed."""
+        assert _git_client is not None  # nosec B101  # addresses linter
         return _git_client.repo is not None
 
 
@@ -225,6 +227,7 @@ class CmdStage(GitRepoCommand):
 
     def on_activate(self):
         """Run the command."""
+        assert _git_client is not None  # nosec B101  # addresses linter
         files_to_process = list()
         for item in self.ide.selection:
             if isinstance(item, FileRef) or isinstance(item, Project):
@@ -255,6 +258,7 @@ class CmdUnstage(GitRepoCommand):
 
     def on_activate(self):
         """Run the command."""
+        assert _git_client is not None  # nosec B101  # addresses linter
         files_to_process = list()
         for item in self.ide.selection:
             if isinstance(item, FileRef) or isinstance(item, Project):
@@ -285,6 +289,7 @@ class CmdReset(GitRepoCommand):
 
     def on_activate(self):
         """Run the command."""
+        assert _git_client is not None  # nosec B101  # addresses linter
         files_to_process = list()
         for item in self.ide.selection:
             if isinstance(item, FileRef) or isinstance(item, Project):
@@ -315,6 +320,7 @@ class CmdStageAll(GitRepoCommand):
 
     def on_activate(self):
         """Run the command."""
+        assert _git_client is not None  # nosec B101  # addresses linter
         refresh_browser(self.ide)
         _git_client.stage(project_files_status[BrowserCat['Unstaged']])
         refresh_browser(self.ide)
@@ -341,6 +347,7 @@ class CmdUnstageAll(GitRepoCommand):
 
     def on_activate(self):
         """Run the command."""
+        assert _git_client is not None  # nosec B101  # addresses linter
         refresh_browser(self.ide)
         _git_client.unstage(project_files_status[BrowserCat['Staged']])
         refresh_browser(self.ide)
@@ -367,6 +374,7 @@ class CmdResetAll(GitRepoCommand):
 
     def on_activate(self):
         """Run the command."""
+        assert _git_client is not None  # nosec B101  # addresses linter
         confirm = self.confirm_reset()
         if confirm:
             _git_client.reset()
@@ -398,6 +406,7 @@ class CmdCommit(GitRepoCommand):
 
     def on_activate(self):
         """Run the command."""
+        assert _git_client is not None  # nosec B101  # addresses linter
         refresh_browser(self.ide)
         if project_files_status[BrowserCat['Unstaged']]:
             confirm = self.confirm_commit()
@@ -439,6 +448,7 @@ class CmdDiff(GitRepoCommand):
 
     def on_activate(self):
         """Run the command."""
+        assert _git_client is not None  # nosec B101  # addresses linter
         branch = self.select_branch()
         if branch:
             branch_path = "".join([c for c in branch if c.isalnum() or c in "._-"])
@@ -451,7 +461,7 @@ class CmdDiff(GitRepoCommand):
             )
             # create a tar archive of the branch
             archive_file = tmp_dir.with_suffix('.tar')
-            _git_client.archive(branch, archive_file)
+            _git_client.archive(branch, str(archive_file))
             if archive_file.exists():
                 # untar the archive in tmp_dir
                 tar_file = tarfile.open(archive_file)
@@ -475,7 +485,7 @@ class CmdDiff(GitRepoCommand):
         return 'main'
 
 
-script_path = Path(os.path.abspath(getsourcefile(lambda: 0)))
+script_path = Path(__file__)
 script_dir = script_path.parent
 
 res = {

--- a/src/ansys/scade/git/extension/gitextension.py
+++ b/src/ansys/scade/git/extension/gitextension.py
@@ -50,9 +50,10 @@ from ansys.scade.git.extension.ide import Ide
 class Studio(Ide):
     """Provide an implementation for SCADE IDE."""
 
-    def create_browser(self, name: str, icon: str = None):
+    def create_browser(self, name: str, icon: str = ''):
         """Redirect the call to SCADE IDE."""
-        scade.create_browser(name, icon)
+        # scade is a CPython module defined dynamically
+        scade.create_browser(name, icon)  # type: ignore
 
     def browser_report(
         self,
@@ -63,19 +64,22 @@ class Studio(Ide):
         icon_file: str = '',
     ):
         """Redirect the call to SCADE IDE."""
+        # scade is a CPython module defined dynamically
         if icon_file:
-            scade.browser_report(item, parent, expanded=expanded, name=name, icon_file=icon_file)
+            scade.browser_report(item, parent, expanded=expanded, name=name, icon_file=icon_file)  # type: ignore
         else:
-            scade.browser_report(item, parent, expanded=expanded, name=name)
+            scade.browser_report(item, parent, expanded=expanded, name=name)  # type: ignore
 
     @property
     def selection(self) -> List[Any]:
         """Redirect the call to SCADE IDE."""
-        return scade.selection
+        # scade is a CPython module defined dynamically
+        return scade.selection  # type: ignore
 
     def get_active_project(self) -> Project:
         """Redirect the call to SCADE IDE."""
-        return scade.get_active_project()
+        # scade is a CPython module defined dynamically
+        return scade.get_active_project()  # type: ignore
 
     def get_projects(self) -> List[Any]:
         """Redirect the call to the API."""
@@ -106,7 +110,8 @@ def log(text: str):
         Message to display.
     """
     if text:
-        scade.tabput("LOG", "Git Extension - " + text + "\n")
+        # scade is a CPython module defined dynamically
+        scade.tabput("LOG", "Git Extension - " + text + "\n")  # type: ignore
 
 
 class SelectBranchDialog(Dialog):
@@ -114,7 +119,7 @@ class SelectBranchDialog(Dialog):
 
     def __init__(self, name):
         super().__init__(name, 300, 200)
-        self.branch = None
+        self.branch = ''
 
     def on_build(self):
         """Build the dialog."""
@@ -129,7 +134,7 @@ class SelectBranchDialog(Dialog):
 
     def on_cancel_click(self, button):
         """Cancel the dialog."""
-        self.branch = None
+        self.branch = ''
         self.close()
 
     def on_list_branch_selection(self, list, index):
@@ -146,7 +151,7 @@ class CommitDialog(Dialog):
 
     def __init__(self, name):
         super().__init__(name, 600, 200)
-        self.commit_text = None
+        self.commit_text = ''
 
     def on_build(self):
         """Build the dialog."""
@@ -157,7 +162,9 @@ class CommitDialog(Dialog):
     def on_close_click(self, button):
         """Close the dialog if the message is not empty."""
         if self.editbox:
-            commit_text = self.editbox.get_name().strip()
+            # Edit.get_name(): wrong typing annotation
+            value: str = self.editbox.get_name()  # type: ignore
+            commit_text = value.strip()
             if commit_text != '':
                 self.commit_text = commit_text
                 self.close()

--- a/src/ansys/scade/git/extension/ide.py
+++ b/src/ansys/scade/git/extension/ide.py
@@ -69,11 +69,13 @@ class Ide(metaclass=ABCMeta):
 
 
 try:
-    from scade.tool.suite.gui.commands import Command as _Command
+    # _Command defined hereafter is a stub, and thus can't match Command
+    from scade.tool.suite.gui.commands import Command as _Command  # type: ignore
 except ImportError:
     import scade
 
-    scade.output('fake activated\n')
+    # scade is a CPython module defined dynamically
+    scade.output('fake activated\n')  # type: ignore
 
     class _Command:
         """Stub for scade.tool.suite.gui.commands.Command."""
@@ -83,7 +85,7 @@ except ImportError:
             name: str,
             status_message: str,
             tooltip_message: str,
-            image_file: str = None,
+            image_file: str = '',
         ):
             self.name = name
             self.status_message = status_message
@@ -93,6 +95,10 @@ except ImportError:
         def on_enable(self) -> bool:
             """Return whether the command can be activated, `True` by default."""
             return True
+
+        def on_activate(self):
+            """Run the command."""
+            pass
 
 
 class Command(_Command):

--- a/src/ansys/scade/git/register.py
+++ b/src/ansys/scade/git/register.py
@@ -30,8 +30,10 @@ from typing import Tuple
 
 from ansys.scade.git import get_srg_name
 
-APPDATA = os.getenv('APPDATA')
-USERPROFILE = os.getenv('USERPROFILE')
+# APPDATA must be defined
+APPDATA = os.environ['APPDATA']
+# USERPROFILE must be defined
+USERPROFILE = os.environ['USERPROFILE']
 
 
 def git_config() -> bool:
@@ -60,7 +62,6 @@ def git_config() -> bool:
 
         return status
 
-    assert USERPROFILE
     # scripts directory in <python>/Scripts
     status = True
     exe = Path(sys.executable)
@@ -108,7 +109,6 @@ def git_config() -> bool:
 
 def register_srg_file(srg: Path, install: Path):
     """Copy the srg file to Customize and patch it with the installation directory."""
-    assert APPDATA
     text = srg.open().read()
     text = text.replace('%TARGETDIR%', install.as_posix())
     dst = Path(APPDATA, 'SCADE', 'Customize', srg.name)

--- a/src/ansys/scade/git/register.py
+++ b/src/ansys/scade/git/register.py
@@ -24,7 +24,7 @@
 
 import os
 from pathlib import Path
-import subprocess
+import subprocess  # nosec B404  # used to call git config
 import sys
 from typing import Tuple
 
@@ -51,7 +51,7 @@ def git_config() -> bool:
             log = cmd[:-1] + ['"%s"' % cmd[-1]]
             print(' '.join(log))
 
-            gitrun = subprocess.run(cmd, capture_output=True, text=True)
+            gitrun = subprocess.run(cmd, capture_output=True, text=True)  # nosec B603  # inputs checked
             if gitrun.stdout:
                 print(gitrun.stdout)
             if gitrun.stderr:

--- a/src/ansys/scade/git/unregister.py
+++ b/src/ansys/scade/git/unregister.py
@@ -24,7 +24,7 @@
 
 import os
 from pathlib import Path
-import subprocess
+import subprocess  # nosec B404  # used to call git config
 import sys
 from typing import Tuple
 
@@ -51,7 +51,7 @@ def git_config() -> bool:
             log = cmd[:-1] + ['"%s"' % cmd[-1]]
             print(' '.join(log))
 
-            gitrun = subprocess.run(cmd, capture_output=True, text=True)
+            gitrun = subprocess.run(cmd, capture_output=True, text=True)  # nosec B603  # inputs checked
             if gitrun.stdout:
                 print(gitrun.stdout)
             if gitrun.stderr:

--- a/src/ansys/scade/git/unregister.py
+++ b/src/ansys/scade/git/unregister.py
@@ -30,8 +30,10 @@ from typing import Tuple
 
 from ansys.scade.git import get_srg_name
 
-APPDATA = os.getenv('APPDATA')
-USERPROFILE = os.getenv('USERPROFILE')
+# APPDATA must be defined
+APPDATA = os.environ['APPDATA']
+# USERPROFILE must be defined
+USERPROFILE = os.environ['USERPROFILE']
 
 
 def git_config() -> bool:
@@ -60,7 +62,6 @@ def git_config() -> bool:
 
         return status
 
-    assert USERPROFILE
     status = True
 
     print('Git: unregister the etpmerge custom merge driver in Git global settings')
@@ -96,7 +97,6 @@ def git_config() -> bool:
 
 def unregister_srg_file(name: str):
     """Delete the srg file from Customize."""
-    assert APPDATA
     dst = Path(APPDATA, 'SCADE', 'Customize', name)
     dst.unlink(missing_ok=True)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,7 +56,8 @@ def lrb(request):
     """Load and return the local, remote and base projects of a directory."""
     dir = Path(request.param)
     names = 'Local.etp', 'Remote.etp', 'Base.etp'
-    return [scade.load_project(str(dir / _)) for _ in names]
+    # scade is a CPython module defined dynamically
+    return [scade.load_project(str(dir / _)) for _ in names]  # type: ignore
 
 
 class TestGitClient(GitClient):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,7 +67,7 @@ class TestGitClient(GitClient):
 
 
 @pytest.fixture(scope='class')
-def tmp_repo(request, tmpdir_factory) -> Tuple[str, GitClient]:
+def tmp_repo(request, tmpdir_factory) -> Tuple[Path, GitClient]:
     """
     Initializes a GitClient for a test directory which is not tracked.
 
@@ -90,7 +90,7 @@ def tmp_repo(request, tmpdir_factory) -> Tuple[str, GitClient]:
 
 
 @pytest.fixture(scope='class')
-def git_repo(request, tmp_repo) -> Tuple[str, GitClient]:
+def git_repo(request, tmp_repo) -> Tuple[Path, GitClient]:
     """
     Initializes a GitClient for a test repository.
 

--- a/tests/extension/test_gitclient.py
+++ b/tests/extension/test_gitclient.py
@@ -20,6 +20,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+# Design note: linter complains about unexisting git_client and dir attributes
+# for test classes: these attributes are added dynamically to the instances
+# by cls_tmp_repo and cls_git_repo fixtures
+# workaround: use 'getattr', or add 'type: ignore' pragma --> too verbose
+
 from pathlib import Path
 from typing import Tuple
 
@@ -38,6 +43,7 @@ UNTRACKED = GitStatus.untracked
 CLEAN = GitStatus.clean
 EXTERN = GitStatus.extern
 ERROR = GitStatus.error
+NONE = GitStatus.none
 
 
 def get_resources_dir() -> Path:
@@ -293,7 +299,7 @@ class TestGitClientRobustnessWrongRepo:
         path = self.dir / 'Model.etp'
         self.git_client.refresh(str(path))
         _, status = self.git_client.get_file_status(path)
-        assert status is None
+        assert status == NONE
 
     def test_stage(self):
         # add any file

--- a/tests/extension/test_gitextcore.py
+++ b/tests/extension/test_gitextcore.py
@@ -22,7 +22,7 @@
 
 import json
 from pathlib import Path
-from typing import Any, List
+from typing import Any, Dict, List
 
 import pytest
 import scade.model.project.stdproject as std
@@ -61,7 +61,7 @@ class StubIde(Ide):
         self.project = None
         self._selection = []
         self.browser = None
-        self.browser_items = None
+        self.browser_items: Dict[Any, Any] = {}
 
     def create_browser(self, name: str, icon: str = ''):
         """Stub scade.create_browser."""
@@ -77,6 +77,7 @@ class StubIde(Ide):
         icon_file: str = '',
     ):
         """Stub scade.browser_report."""
+        assert self.browser_items is not None
         if isinstance(item, str):
             child = item
         else:
@@ -104,6 +105,7 @@ class StubIde(Ide):
 
     def get_active_project(self) -> std.Project:
         """Stub scade.active_project."""
+        assert self.project is not None
         return self.project
 
     def get_projects(self) -> List[Any]:
@@ -155,7 +157,8 @@ def model_repo(request, git_repo):
 
     core.set_git_client(client)
     project_path = tmp_dir / 'Model' / 'Model.etp'
-    _test_ide.project = scade.load_project(str(project_path))
+    # scade is a CPython module defined dynamically
+    _test_ide.project = scade.load_project(str(project_path))  # type: ignore
     client.refresh(str(path))
 
     return tmp_dir

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,6 +25,7 @@
 import difflib
 from pathlib import Path
 from subprocess import run
+from typing import Optional
 
 
 def get_resources_dir() -> Path:
@@ -53,7 +54,7 @@ def cmp_file(fromfile: Path, tofile: Path, n=3, linejunk=None):
     return diff
 
 
-def run_git(command: str, *args: str, dir=None) -> bool:
+def run_git(command: str, *args: str, dir: Optional[Path] = None) -> bool:
     """Run a git command."""
     cmd = ['git']
     if dir:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,15 +23,13 @@
 """Helpers for test_*.py."""
 
 import difflib
-from inspect import getsourcefile
-import os
 from pathlib import Path
 from subprocess import run
 
 
 def get_resources_dir() -> Path:
     """Return the directory ./resources relative to this file's directory."""
-    script_path = Path(os.path.abspath(getsourcefile(lambda: 0)))
+    script_path = Path(__file__)
     return script_path.parent
 
 


### PR DESCRIPTION
Enhance the package's robustness with the following actions:
* Resolve linter errors
* Remove or verify the usage of assertions
* Check the inputs of process calls
* Avoid using eval
* Specify an exact version of dulwich
* Filter the links extracted from an archive